### PR TITLE
Feat/get-book-by-id

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,7 @@ COPY nginx.conf /etc/nginx/nginx.conf
 # Copy Supervisor configuration
 COPY supervisord.conf /etc/supervisor/supervisord.conf
 
+
 # Expose port 8080 for Nginx
 EXPOSE 8080
 

--- a/fly.toml
+++ b/fly.toml
@@ -1,20 +1,16 @@
 # fly.toml app configuration file generated for fastapi-book-project-icy-surf-8769 on 2025-02-12T01:43:52+01:00
-#
-# See https://fly.io/docs/reference/configuration/ for information about how to use this file.
-#
 
 app = 'fastapi-book-project-icy-surf-8769'
 primary_region = 'lhr'
-
-[build]
 
 [http_service]
   internal_port = 8080
   force_https = true
   auto_stop_machines = true
   auto_start_machines = true
-  min_machines_running = 1
+  min_machines_running = 0
   processes = ['app']
+
 
 [[vm]]
   memory = '1gb'

--- a/nginx.conf
+++ b/nginx.conf
@@ -5,6 +5,7 @@ events {
 }
 
 http {
+    
     include mime.types;
     default_type application/octet-stream;
     sendfile on;
@@ -27,6 +28,8 @@ http {
             proxy_http_version 1.1;
             proxy_set_header Upgrade $http_upgrade;
             proxy_set_header Connection "Upgrade";
+        
+            add_header Server "nginx";
         }
 
         error_page 500 502 503 504 /50x.html;

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -9,7 +9,7 @@ stderr_logfile=/dev/stderr
 stdout_logfile=/dev/stdout
 
 [program:uvicorn]
-command=uvicorn main:app --host 0.0.0.0 --port 8000
+command=uvicorn main:app --host 0.0.0.0 --port 8000 --workers 4
 autostart=true
 autorestart=true
 stderr_logfile=/dev/stderr


### PR DESCRIPTION
## Description  
- Added GET `/api/v1/books/{book_id}` endpoint to retrieve book details.  
- Configured Nginx reverse proxy for FastAPI.  

## Related Task  
[HNG12 Stage 2 Task]  "https://hng12.slack.com/archives/C088PK3KE2K/p1739195475622999"

## Testing  
- Ran `pytest` locally (all tests passed).  
- Tested invalid IDs (e.g., `/books/4`) to confirm 404 response.  

## Notes  
- Installed hng12-bot.  
- Deployment URL: "https://fastapi-book-project-icy-surf-8769.fly.dev/"